### PR TITLE
Add minutes-level precision to Debian build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             docker buildx build \
               --platform linux/arm/v7 \
               --build-arg PKG_VERSION \
-              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d')" \
+              --build-arg "PKG_BUILD_NUMBER=$(date '+%Y%m%d%H%M')" \
               --target=artifact \
               --progress=plain \
               --output type=local,dest=$(pwd)/releases/ \


### PR DESCRIPTION
It's possible that we'll have to build multiple times in the same day (like today), so it's better to have more precision.